### PR TITLE
Hides SteamVR popup in noGraphics mode

### DIFF
--- a/Editor/SteamVR_Settings.cs
+++ b/Editor/SteamVR_Settings.cs
@@ -101,7 +101,7 @@ public class SteamVR_Settings : EditorWindow
 #endif
 			forceShow;
 
-		if (show)
+		if (SystemInfo.graphicsDeviceID != 0 && show)
 		{
 			window = GetWindow<SteamVR_Settings>(true);
 			window.minSize = new Vector2(320, 440);


### PR DESCRIPTION
This is so Travis doesn’t fail because SteamVR blocks the testing